### PR TITLE
Adapt transformHtml to make the images in the html actually lazyload

### DIFF
--- a/src/ImgixTransformer.js
+++ b/src/ImgixTransformer.js
@@ -72,7 +72,9 @@ export default class ImgixTransformer {
       const wrapperEl = document.createElement('div')
       wrapperEl.innerHTML = match
       const imagePath = wrapperEl.firstChild.getAttribute('src')
-      wrapperEl.firstChild.src = this.transformUrl(imagePath, options)
+      wrapperEl.firstChild.src = 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=='
+      wrapperEl.firstChild.dataset.src = this.transformUrl(imagePath, options)
+      wrapperEl.firstChild.classList.add('lazyload')
 
       return wrapperEl.innerHTML
     }

--- a/src/components/ImagixHtmlTransformer.vue
+++ b/src/components/ImagixHtmlTransformer.vue
@@ -1,8 +1,6 @@
 <template>
-  <div>
-    <!-- eslint-disable-next-line -->
-    <div v-if="html" v-html="transformedHtml"></div>
-  </div>
+  <!-- eslint-disable-next-line -->
+  <div v-if="html" v-html="transformedHtml"></div>
 </template>
 <script>
 


### PR DESCRIPTION
Adapt `transformHtml` method to make the images in the html actually lazyload, so that the image doesn't load at initial page loads.