### PR TITLE
Remove unnecessary ImgixImage props

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sparwelt/vue-imgix-transformer",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "Vue component plugin to convert Imgix urls",
   "author": "Sparwelt",
   "license": "MIT",

--- a/src/components/ImgixImage.vue
+++ b/src/components/ImgixImage.vue
@@ -4,9 +4,6 @@
        :data-src="transformedDataSrc"
        :data-srcset="transformedDataSrcset"
        :data-sizes="transformedDataSizes"
-       :alt="alt"
-       :title="title"
-       :id="id"
   />
 </template>
 <script>
@@ -45,18 +42,6 @@
           return ['auto']
         },
         type: Array
-      },
-      alt: {
-        default: '',
-        type: String
-      },
-      title: {
-        default: '',
-        type: String
-      },
-      id: {
-        default: null,
-        type: String
       },
       config: {
         default: null,


### PR DESCRIPTION
Reasoning: Not providing title or alt would cause an empty title to be rendered, preventing titles from other elements to be shown.
Since the attributes bound to the ImgixImage are applied to the <img> by Vue, there is no need to manually provide them.